### PR TITLE
Automatic update of CliFx to 2.0.3

### DIFF
--- a/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.2" />
+    <PackageReference Include="CliFx" Version="2.0.3" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `CliFx` to `2.0.3` from `2.0.2`
`CliFx 2.0.3` was published at `2021-04-09T19:25:02Z`, 7 days ago

1 project update:
Updated `CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.0.3` from `2.0.2`

[CliFx 2.0.3 on NuGet.org](https://www.nuget.org/packages/CliFx/2.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
