### PR TITLE
Automatic update of Nuke.Common to 5.1.1

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.Common" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Nuke.Common` to `5.1.1` from `5.1.0`
`Nuke.Common 5.1.1` was published at `2021-04-23T15:51:55Z`, 14 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `5.1.1` from `5.1.0`

[Nuke.Common 5.1.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
