### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.Common" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.0.4" />
+    <PackageReference Include="FluentValidation" Version="10.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.3" />
+    <PackageReference Include="CliFx" Version="2.0.4" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />


### PR DESCRIPTION
3 packages were updated in 3 projects:
`FluentValidation`, `Nuke.Common`, `CliFx`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation` to `10.1.0` from `10.0.4`
`FluentValidation 10.1.0` was published at `2021-04-28T07:31:07Z`, 22 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.1.0` from `10.0.4`

[FluentValidation 10.1.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.1.0)

NuKeeper has generated a patch update of `Nuke.Common` to `5.1.1` from `5.1.0`
`Nuke.Common 5.1.1` was published at `2021-04-23T15:51:55Z`, 5 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `5.1.1` from `5.1.0`

[Nuke.Common 5.1.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.1)

NuKeeper has generated a patch update of `CliFx` to `2.0.4` from `2.0.3`
`CliFx 2.0.4` was published at `2021-04-24T18:00:03Z`, 4 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.0.4` from `2.0.3`

[CliFx 2.0.4 on NuGet.org](https://www.nuget.org/packages/CliFx/2.0.4)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
