### PR TITLE
Automatic update of 6 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -11,7 +11,7 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.Common" Version="5.1.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />

--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -1,5 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
@@ -10,13 +10,10 @@
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.1.0" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
+    <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />
   </ItemGroup>
-
 </Project>

--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -25,6 +25,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.10.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.10.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.0.4" />
+    <PackageReference Include="FluentValidation" Version="10.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.3" />
+    <PackageReference Include="CliFx" Version="2.0.4" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -28,6 +28,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.10.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.10.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.21.0.30542" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
6 packages were updated in 6 projects:
`Microsoft.Unity.Analyzers`, `FluentValidation`, `CliFx`, `dotnet-format`, `SonarAnalyzer.CSharp`, `Nuke.Common`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Microsoft.Unity.Analyzers` to `1.10.2` from `1.10.1`
`Microsoft.Unity.Analyzers 1.10.2` was published at `2021-04-29T16:49:37Z`, 22 days ago

2 project updates:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.10.2` from `1.10.1`
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.10.2` from `1.10.1`

[Microsoft.Unity.Analyzers 1.10.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Unity.Analyzers/1.10.2)

NuKeeper has generated a minor update of `FluentValidation` to `10.1.0` from `10.0.4`
`FluentValidation 10.1.0` was published at `2021-04-28T07:31:07Z`, 23 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.1.0` from `10.0.4`

[FluentValidation 10.1.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.1.0)

NuKeeper has generated a patch update of `CliFx` to `2.0.4` from `2.0.3`
`CliFx 2.0.4` was published at `2021-04-24T18:00:03Z`, 27 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.0.4` from `2.0.3`

[CliFx 2.0.4 on NuGet.org](https://www.nuget.org/packages/CliFx/2.0.4)

NuKeeper has generated a minor update of `dotnet-format` to `5.1.225507` from `5.0.211103`
`dotnet-format 5.1.225507` was published at `2021-05-05T18:47:14Z`, 16 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `dotnet-format` `5.1.225507` from `5.0.211103`

[dotnet-format 5.1.225507 on NuGet.org](https://www.nuget.org/packages/dotnet-format/5.1.225507)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.23.0.32424` from `8.21.0.30542`
`SonarAnalyzer.CSharp 8.23.0.32424` was published at `2021-05-21T12:24:16Z`, 17 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.23.0.32424` from `8.21.0.30542`

[SonarAnalyzer.CSharp 8.23.0.32424 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.23.0.32424)

NuKeeper has generated a patch update of `Nuke.Common` to `5.1.2` from `5.1.0`
`Nuke.Common 5.1.2` was published at `2021-05-18T22:08:18Z`, 3 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `5.1.2` from `5.1.0`

[Nuke.Common 5.1.2 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
