### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.24.0.32949

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.24.0.32949` from `8.23.0.32424`
`SonarAnalyzer.CSharp 8.24.0.32949` was published at `2021-06-07T14:40:24Z`, 15 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.24.0.32949` from `8.23.0.32424`

[SonarAnalyzer.CSharp 8.24.0.32949 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.24.0.32949)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
