### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
2 packages were updated in 1 project:
`SonarAnalyzer.CSharp`, `Roslynator.Analyzers`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.24.0.32949` from `8.23.0.32424`
`SonarAnalyzer.CSharp 8.24.0.32949` was published at `2021-06-07T14:40:24Z`, 4 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.24.0.32949` from `8.23.0.32424`

[SonarAnalyzer.CSharp 8.24.0.32949 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.24.0.32949)

NuKeeper has generated a minor update of `Roslynator.Analyzers` to `3.2.0` from `3.1.0`
`Roslynator.Analyzers 3.2.0` was published at `2021-06-11T13:24:04Z`, 16 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `3.2.0` from `3.1.0`

[Roslynator.Analyzers 3.2.0 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/3.2.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
