### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="FluentValidation" Version="10.3.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.4" />
+    <PackageReference Include="CliFx" Version="2.0.5" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.10.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />


### PR DESCRIPTION
2 packages were updated in 2 projects:
`FluentValidation`, `CliFx`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation` to `10.3.0` from `10.2.3`
`FluentValidation 10.3.0` was published at `2021-07-09T09:10:45Z`, 21 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.3.0` from `10.2.3`

[FluentValidation 10.3.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.3.0)

NuKeeper has generated a patch update of `CliFx` to `2.0.5` from `2.0.4`
`CliFx 2.0.5` was published at `2021-07-09T19:24:31Z`, 10 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.0.5` from `2.0.4`

[CliFx 2.0.5 on NuGet.org](https://www.nuget.org/packages/CliFx/2.0.5)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
