### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="FluentValidation" Version="10.3.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.10.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.4" />
+    <PackageReference Include="CliFx" Version="2.0.6" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.10.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.25.0.33663" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.26.0.34506" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
4 packages were updated in 3 projects:
`FluentValidation`, `SonarAnalyzer.CSharp`, `Microsoft.Extensions.DependencyInjection`, `CliFx`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation` to `10.3.0` from `10.2.3`
`FluentValidation 10.3.0` was published at `2021-07-09T09:10:45Z`, 8 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.3.0` from `10.2.3`

[FluentValidation 10.3.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.3.0)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.26.0.34506` from `8.25.0.33663`
`SonarAnalyzer.CSharp 8.26.0.34506` was published at `2021-07-12T13:42:17Z`, 5 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.26.0.34506` from `8.25.0.33663`

[SonarAnalyzer.CSharp 8.26.0.34506 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.26.0.34506)

NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection` to `5.0.2` from `5.0.1`
`Microsoft.Extensions.DependencyInjection 5.0.2` was published at `2021-07-13T13:36:40Z`, 4 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Extensions.DependencyInjection` `5.0.2` from `5.0.1`

[Microsoft.Extensions.DependencyInjection 5.0.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/5.0.2)

NuKeeper has generated a patch update of `CliFx` to `2.0.6` from `2.0.4`
`CliFx 2.0.6` was published at `2021-07-17T18:38:21Z`, 11 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.0.6` from `2.0.4`

[CliFx 2.0.6 on NuGet.org](https://www.nuget.org/packages/CliFx/2.0.6)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
