### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.2.1" />
+    <PackageReference Include="Nuke.Common" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
2 packages were updated in 2 projects:
`coverlet.collector`, `Nuke.Common`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `coverlet.collector` to `3.1.0` from `3.0.3`
`coverlet.collector 3.1.0` was published at `2021-07-19T18:00:25Z`, 16 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `coverlet.collector` `3.1.0` from `3.0.3`

[coverlet.collector 3.1.0 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.1.0)

NuKeeper has generated a minor update of `Nuke.Common` to `5.3.0` from `5.2.1`
`Nuke.Common 5.3.0` was published at `2021-08-04T06:49:23Z`, 23 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `5.3.0` from `5.2.1`

[Nuke.Common 5.3.0 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.3.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
