### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.2.1" />
+    <PackageReference Include="Nuke.Common" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.26.0.34506" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.27.0.35380" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
4 packages were updated in 3 projects:
`coverlet.collector`, `Nuke.Common`, `SonarAnalyzer.CSharp`, `Microsoft.NET.Test.Sdk`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `coverlet.collector` to `3.1.0` from `3.0.3`
`coverlet.collector 3.1.0` was published at `2021-07-19T18:00:25Z`, 25 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `coverlet.collector` `3.1.0` from `3.0.3`

[coverlet.collector 3.1.0 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.1.0)

NuKeeper has generated a minor update of `Nuke.Common` to `5.3.0` from `5.2.1`
`Nuke.Common 5.3.0` was published at `2021-08-04T06:49:23Z`, 9 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `5.3.0` from `5.2.1`

[Nuke.Common 5.3.0 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.3.0)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.27.0.35380` from `8.26.0.34506`
`SonarAnalyzer.CSharp 8.27.0.35380` was published at `2021-08-06T12:56:11Z`, 7 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.27.0.35380` from `8.26.0.34506`

[SonarAnalyzer.CSharp 8.27.0.35380 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.27.0.35380)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.11.0` from `16.10.0`
`Microsoft.NET.Test.Sdk 16.11.0` was published at `2021-08-13T13:42:02Z`, 16 hours ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.11.0` from `16.10.0`

[Microsoft.NET.Test.Sdk 16.11.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.11.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
