### PR TITLE
Automatic update of Roslynator.Analyzers to 3.2.2

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.2.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.27.0.35380" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Roslynator.Analyzers` to `3.2.2` from `3.2.0`
`Roslynator.Analyzers 3.2.2` was published at `2021-08-15T21:02:36Z`, 9 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `3.2.2` from `3.2.0`

[Roslynator.Analyzers 3.2.2 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/3.2.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
