### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.0" />
+    <PackageReference Include="FluentValidation" Version="10.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.0.6" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Microsoft.Build" Version="16.11.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.0.6" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
-    <PackageReference Include="Microsoft.Build" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.11.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Microsoft.Build`, `Microsoft.Build.Utilities.Core`, `FluentValidation`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Build` to `16.11.0` from `16.10.0`
`Microsoft.Build 16.11.0` was published at `2021-08-19T17:01:16Z`, 13 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `16.11.0` from `16.10.0`

[Microsoft.Build 16.11.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/16.11.0)

NuKeeper has generated a minor update of `Microsoft.Build.Utilities.Core` to `16.11.0` from `16.10.0`
`Microsoft.Build.Utilities.Core 16.11.0` was published at `2021-08-19T17:01:32Z`, 13 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `16.11.0` from `16.10.0`

[Microsoft.Build.Utilities.Core 16.11.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/16.11.0)

NuKeeper has generated a patch update of `FluentValidation` to `10.3.1` from `10.3.0`
`FluentValidation 10.3.1` was published at `2021-08-19T16:25:00Z`, 13 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.3.1` from `10.3.0`

[FluentValidation 10.3.1 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.3.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
