### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.30.0.37606

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.29.0.36737" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.30.0.37606` from `8.29.0.36737`
`SonarAnalyzer.CSharp 8.30.0.37606` was published at `2021-10-06T07:23:12Z`, 22 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.30.0.37606` from `8.29.0.36737`

[SonarAnalyzer.CSharp 8.30.0.37606 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.30.0.37606)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
