### PR TITLE
Automatic update of 8 packages

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.0.6" />
     <PackageReference Include="CliWrap" Version="3.3.3" />
-    <PackageReference Include="Microsoft.Build" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.0.6" />
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.31.0.39249" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
8 packages were updated in 3 projects:
`System.Collections.Immutable`, `System.Text.Json`, `Microsoft.Build`, `Microsoft.Build.Utilities.Core`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.SourceLink.GitHub`, `SonarAnalyzer.CSharp`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `System.Collections.Immutable` to `6.0.0` from `5.0.0`
`System.Collections.Immutable 6.0.0` was published at `2021-11-08T06:28:23Z`, 2 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Collections.Immutable` `6.0.0` from `5.0.0`

[System.Collections.Immutable 6.0.0 on NuGet.org](https://www.nuget.org/packages/System.Collections.Immutable/6.0.0)

NuKeeper has generated a major update of `System.Text.Json` to `6.0.0` from `5.0.2`
`System.Text.Json 6.0.0` was published at `2021-11-08T06:35:35Z`, 2 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Text.Json` `6.0.0` from `5.0.2`

[System.Text.Json 6.0.0 on NuGet.org](https://www.nuget.org/packages/System.Text.Json/6.0.0)

NuKeeper has generated a major update of `Microsoft.Build` to `17.0.0` from `16.11.0`
`Microsoft.Build 17.0.0` was published at `2021-11-08T21:54:07Z`, 2 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `17.0.0` from `16.11.0`

[Microsoft.Build 17.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/17.0.0)

NuKeeper has generated a major update of `Microsoft.Build.Utilities.Core` to `17.0.0` from `16.11.0`
`Microsoft.Build.Utilities.Core 17.0.0` was published at `2021-11-08T21:53:33Z`, 2 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `17.0.0` from `16.11.0`

[Microsoft.Build.Utilities.Core 17.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/17.0.0)

NuKeeper has generated a major update of `Microsoft.Extensions.DependencyInjection` to `6.0.0` from `5.0.2`
`Microsoft.Extensions.DependencyInjection 6.0.0` was published at `2021-11-08T06:37:01Z`, 2 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Extensions.DependencyInjection` `6.0.0` from `5.0.2`

[Microsoft.Extensions.DependencyInjection 6.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/6.0.0)

NuKeeper has generated a major update of `Microsoft.Extensions.Hosting` to `6.0.0` from `5.0.0`
`Microsoft.Extensions.Hosting 6.0.0` was published at `2021-11-08T06:29:09Z`, 2 days ago

1 project update:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj` to `Microsoft.Extensions.Hosting` `6.0.0` from `5.0.0`

[Microsoft.Extensions.Hosting 6.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/6.0.0)

NuKeeper has generated a minor update of `Microsoft.SourceLink.GitHub` to `1.1.1` from `1.0.0`
`Microsoft.SourceLink.GitHub 1.1.1` was published at `2021-11-10T20:35:32Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.SourceLink.GitHub` `1.1.1` from `1.0.0`

[Microsoft.SourceLink.GitHub 1.1.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub/1.1.1)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.31.0.39249` from `8.30.0.37606`
`SonarAnalyzer.CSharp 8.31.0.39249` was published at `2021-11-10T18:00:50Z`, 12 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.31.0.39249` from `8.30.0.37606`

[SonarAnalyzer.CSharp 8.31.0.39249 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.31.0.39249)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
