### PR TITLE
Automatic update of Microsoft.Unity.Analyzers to 1.11.2

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -25,6 +25,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -28,6 +28,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Unity.Analyzers` to `1.11.2` from `1.11.1`
`Microsoft.Unity.Analyzers 1.11.2` was published at `2021-11-25T15:34:07Z`, 14 hours ago

2 project updates:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.11.2` from `1.11.1`
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.11.2` from `1.11.1`

[Microsoft.Unity.Analyzers 1.11.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Unity.Analyzers/1.11.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
