### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -25,6 +25,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.4" />
+    <PackageReference Include="FluentValidation" Version="10.3.5" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -28,6 +28,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
3 packages were updated in 4 projects:
`Microsoft.Unity.Analyzers`, `Roslynator.Analyzers`, `FluentValidation`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Microsoft.Unity.Analyzers` to `1.11.2` from `1.11.1`
`Microsoft.Unity.Analyzers 1.11.2` was published at `2021-11-25T15:34:07Z`, 5 days ago

2 project updates:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.11.2` from `1.11.1`
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.11.2` from `1.11.1`

[Microsoft.Unity.Analyzers 1.11.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Unity.Analyzers/1.11.2)

NuKeeper has generated a minor update of `Roslynator.Analyzers` to `3.3.0` from `3.2.2`
`Roslynator.Analyzers 3.3.0` was published at `2021-11-28T19:36:03Z`, 2 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `3.3.0` from `3.2.2`

[Roslynator.Analyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/3.3.0)

NuKeeper has generated a patch update of `FluentValidation` to `10.3.5` from `10.3.4`
`FluentValidation 10.3.5` was published at `2021-11-30T21:15:09Z`, 9 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.3.5` from `10.3.4`

[FluentValidation 10.3.5 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.3.5)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
