### PR TITLE
Automatic update of FluentValidation to 10.3.6

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.5" />
+    <PackageReference Include="FluentValidation" Version="10.3.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentValidation` to `10.3.6` from `10.3.5`
`FluentValidation 10.3.6` was published at `2021-12-13T14:55:51Z`, 15 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.3.6` from `10.3.5`

[FluentValidation 10.3.6 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.3.6)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
