### PR TITLE
Automatic update of CliFx to 2.1.0

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.6" />
+    <PackageReference Include="CliFx" Version="2.1.0" />
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `CliFx` to `2.1.0` from `2.0.6`
`CliFx 2.1.0` was published at `2022-01-04T20:41:18Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.1.0` from `2.0.6`

[CliFx 2.1.0 on NuGet.org](https://www.nuget.org/packages/CliFx/2.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
