### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.1" />
-    <PackageReference Include="CliWrap" Version="3.3.3" />
+    <PackageReference Include="CliWrap" Version="3.4.0" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.0.6" />
+    <PackageReference Include="CliFx" Version="2.2.1" />
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.34.0.42011" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
4 packages were updated in 3 projects:
`Nuke.Common`, `CliFx`, `CliWrap`, `SonarAnalyzer.CSharp`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Nuke.Common` to `6.0.1` from `5.3.0`
`Nuke.Common 6.0.1` was published at `2022-01-10T21:42:54Z`, 7 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.0.1` from `5.3.0`

[Nuke.Common 6.0.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.0.1)

NuKeeper has generated a minor update of `CliFx` to `2.2.1` from `2.0.6`
`CliFx 2.2.1` was published at `2022-01-16T17:34:26Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.1` from `2.0.6`

[CliFx 2.2.1 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.1)

NuKeeper has generated a minor update of `CliWrap` to `3.4.0` from `3.3.3`
`CliWrap 3.4.0` was published at `2022-01-07T18:10:40Z`, 10 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliWrap` `3.4.0` from `3.3.3`

[CliWrap 3.4.0 on NuGet.org](https://www.nuget.org/packages/CliWrap/3.4.0)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.34.0.42011` from `8.33.0.40503`
`SonarAnalyzer.CSharp 8.34.0.42011` was published at `2022-01-17T11:02:29Z`, 19 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.34.0.42011` from `8.33.0.40503`

[SonarAnalyzer.CSharp 8.34.0.42011 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.34.0.42011)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
