### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -25,6 +25,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.12.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -28,6 +28,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.11.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.12.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.0.0" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.34.0.42011" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
2 packages were updated in 3 projects:
`Microsoft.Unity.Analyzers`, `Roslynator.Analyzers`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Unity.Analyzers` to `1.12.0` from `1.11.2`
`Microsoft.Unity.Analyzers 1.12.0` was published at `2022-01-19T17:55:23Z`, 8 days ago

2 project updates:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.12.0` from `1.11.2`
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.12.0` from `1.11.2`

[Microsoft.Unity.Analyzers 1.12.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Unity.Analyzers/1.12.0)

NuKeeper has generated a major update of `Roslynator.Analyzers` to `4.0.0` from `3.3.0`
`Roslynator.Analyzers 4.0.0` was published at `2022-01-21T22:28:32Z`, 6 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `4.0.0` from `3.3.0`

[Roslynator.Analyzers 4.0.0 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/4.0.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
