### PR TITLE
Automatic update of 5 packages

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.1" />
+    <PackageReference Include="CliFx" Version="2.2.2" />
     <PackageReference Include="CliWrap" Version="3.4.0" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.2" />
-    <PackageReference Include="CliWrap" Version="3.4.0" />
+    <PackageReference Include="CliWrap" Version="3.4.1" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.34.0.42011" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.35.0.42613" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.0.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.35.0.42613" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
5 packages were updated in 3 projects:
`SonarAnalyzer.CSharp`, `Roslynator.Analyzers`, `coverlet.collector`, `CliFx`, `CliWrap`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.35.0.42613` from `8.34.0.42011`
`SonarAnalyzer.CSharp 8.35.0.42613` was published at `2022-01-31T08:32:52Z`, 21 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.35.0.42613` from `8.34.0.42011`

[SonarAnalyzer.CSharp 8.35.0.42613 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.35.0.42613)

NuKeeper has generated a patch update of `Roslynator.Analyzers` to `4.0.2` from `4.0.0`
`Roslynator.Analyzers 4.0.2` was published at `2022-01-29T13:21:14Z`, 2 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `4.0.2` from `4.0.0`

[Roslynator.Analyzers 4.0.2 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/4.0.2)

NuKeeper has generated a patch update of `coverlet.collector` to `3.1.1` from `3.1.0`
`coverlet.collector 3.1.1` was published at `2022-01-30T11:03:54Z`, 1 day ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `coverlet.collector` `3.1.1` from `3.1.0`

[coverlet.collector 3.1.1 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.1.1)

NuKeeper has generated a patch update of `CliFx` to `2.2.2` from `2.2.1`
`CliFx 2.2.2` was published at `2022-01-30T17:14:22Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.2` from `2.2.1`

[CliFx 2.2.2 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.2)

NuKeeper has generated a patch update of `CliWrap` to `3.4.1` from `3.4.0`
`CliWrap 3.4.1` was published at `2022-01-30T18:01:31Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliWrap` `3.4.1` from `3.4.0`

[CliWrap 3.4.1 on NuGet.org](https://www.nuget.org/packages/CliWrap/3.4.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
