### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.1">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
3 packages were updated in 3 projects:
`coverlet.collector`, `System.Text.Json`, `Microsoft.Extensions.Hosting`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `coverlet.collector` to `3.1.2` from `3.1.1`
`coverlet.collector 3.1.2` was published at `2022-02-06T16:27:22Z`, 2 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `coverlet.collector` `3.1.2` from `3.1.1`

[coverlet.collector 3.1.2 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.1.2)

NuKeeper has generated a patch update of `System.Text.Json` to `6.0.2` from `6.0.1`
`System.Text.Json 6.0.2` was published at `2022-02-08T16:15:41Z`, 14 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Text.Json` `6.0.2` from `6.0.1`

[System.Text.Json 6.0.2 on NuGet.org](https://www.nuget.org/packages/System.Text.Json/6.0.2)

NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting` to `6.0.1` from `6.0.0`
`Microsoft.Extensions.Hosting 6.0.1` was published at `2022-02-08T16:00:48Z`, 14 hours ago

1 project update:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Sample/Sample.csproj` to `Microsoft.Extensions.Hosting` `6.0.1` from `6.0.0`

[Microsoft.Extensions.Hosting 6.0.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/6.0.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
