### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 17.1.0

### DIFF
--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `17.1.0` from `17.0.0`
`Microsoft.NET.Test.Sdk 17.1.0` was published at `2022-02-16T14:06:31Z`, 16 hours ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.1.0` from `17.0.0`

[Microsoft.NET.Test.Sdk 17.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
