### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.36.0.43782

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.35.0.42613" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.0.43782" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.36.0.43782` from `8.35.0.42613`
`SonarAnalyzer.CSharp 8.36.0.43782` was published at `2022-02-23T07:42:50Z`, 22 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.36.0.43782` from `8.35.0.42613`

[SonarAnalyzer.CSharp 8.36.0.43782 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.36.0.43782)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
