### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.2" />
     <PackageReference Include="CliWrap" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.2.2" />
     <PackageReference Include="CliWrap" Version="3.4.1" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Build`, `Microsoft.Build.Utilities.Core`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Build` to `17.1.0` from `17.0.0`
`Microsoft.Build 17.1.0` was published at `2022-03-08T20:49:23Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `17.1.0` from `17.0.0`

[Microsoft.Build 17.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/17.1.0)

NuKeeper has generated a minor update of `Microsoft.Build.Utilities.Core` to `17.1.0` from `17.0.0`
`Microsoft.Build.Utilities.Core 17.1.0` was published at `2022-03-08T20:49:37Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `17.1.0` from `17.0.0`

[Microsoft.Build.Utilities.Core 17.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/17.1.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
