### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.6" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.2" />
     <PackageReference Include="CliWrap" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.2" />
-    <PackageReference Include="CliWrap" Version="3.4.1" />
+    <PackageReference Include="CliWrap" Version="3.4.2" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.2.2" />
     <PackageReference Include="CliWrap" Version="3.4.1" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />


### PR DESCRIPTION
4 packages were updated in 2 projects:
`Microsoft.Build`, `Microsoft.Build.Utilities.Core`, `FluentValidation`, `CliWrap`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Build` to `17.1.0` from `17.0.0`
`Microsoft.Build 17.1.0` was published at `2022-03-08T20:49:23Z`, 6 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `17.1.0` from `17.0.0`

[Microsoft.Build 17.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/17.1.0)

NuKeeper has generated a minor update of `Microsoft.Build.Utilities.Core` to `17.1.0` from `17.0.0`
`Microsoft.Build.Utilities.Core 17.1.0` was published at `2022-03-08T20:49:37Z`, 6 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `17.1.0` from `17.0.0`

[Microsoft.Build.Utilities.Core 17.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/17.1.0)

NuKeeper has generated a minor update of `FluentValidation` to `10.4.0` from `10.3.6`
`FluentValidation 10.4.0` was published at `2022-03-11T09:46:37Z`, 3 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `10.4.0` from `10.3.6`

[FluentValidation 10.4.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/10.4.0)

NuKeeper has generated a patch update of `CliWrap` to `3.4.2` from `3.4.1`
`CliWrap 3.4.2` was published at `2022-03-14T22:09:19Z`, 7 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliWrap` `3.4.2` from `3.4.1`

[CliWrap 3.4.2 on NuGet.org](https://www.nuget.org/packages/CliWrap/3.4.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
