### PR TITLE
Automatic update of Roslynator.Analyzers to 4.1.0

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.1.0" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.1.44192" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Roslynator.Analyzers` to `4.1.0` from `4.0.2`
`Roslynator.Analyzers 4.1.0` was published at `2022-03-29T20:58:14Z`, 9 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `4.1.0` from `4.0.2`

[Roslynator.Analyzers 4.1.0 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/4.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
