### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.37.0.45539

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.1.44192" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.37.0.45539` from `8.36.1.44192`
`SonarAnalyzer.CSharp 8.37.0.45539` was published at `2022-03-30T09:58:08Z`, 20 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.37.0.45539` from `8.36.1.44192`

[SonarAnalyzer.CSharp 8.37.0.45539 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.37.0.45539)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
