### PR TITLE
Automatic update of Microsoft.Unity.Analyzers to 1.13.0

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -25,6 +25,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -28,6 +28,6 @@
     <PackageReference Include="Unity3D" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Unity.Analyzers` to `1.13.0` from `1.12.0`
`Microsoft.Unity.Analyzers 1.13.0` was published at `2022-04-04T15:02:09Z`, 15 hours ago

2 project updates:
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.13.0` from `1.12.0`
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Microsoft.Unity.Analyzers` `1.13.0` from `1.12.0`

[Microsoft.Unity.Analyzers 1.13.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Unity.Analyzers/1.13.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
