### PR TITLE
Automatic update of System.Text.Json to 6.0.3

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.Text.Json` to `6.0.3` from `6.0.2`
`System.Text.Json 6.0.3` was published at `2022-04-12T00:04:57Z`, 6 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Text.Json` `6.0.3` from `6.0.2`

[System.Text.Json 6.0.3 on NuGet.org](https://www.nuget.org/packages/System.Text.Json/6.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
