### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageReference Include="Nuke.Common" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.2" />
+    <PackageReference Include="CliFx" Version="2.2.3" />
     <PackageReference Include="CliWrap" Version="3.4.2" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />


### PR DESCRIPTION
2 packages were updated in 2 projects:
`Nuke.Common`, `CliFx`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Nuke.Common` to `6.0.2` from `6.0.1`
`Nuke.Common 6.0.2` was published at `2022-04-12T23:15:18Z`, 4 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.0.2` from `6.0.1`

[Nuke.Common 6.0.2 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.0.2)

NuKeeper has generated a patch update of `CliFx` to `2.2.3` from `2.2.2`
`CliFx 2.2.3` was published at `2022-04-17T00:26:22Z`, 5 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.3` from `2.2.2`

[CliFx 2.2.3 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
