### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageReference Include="Nuke.Common" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Samples/CsprojToAsmdef.Sample/Assets/SampleUnityDependency/SampleUnityDependency.csproj
+++ b/Samples/CsprojToAsmdef.Sample/Assets/SampleUnityDependency/SampleUnityDependency.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.2" />
+    <PackageReference Include="CliFx" Version="2.2.4" />
     <PackageReference Include="CliWrap" Version="3.4.3" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.2" />
-    <PackageReference Include="CliWrap" Version="3.4.2" />
+    <PackageReference Include="CliWrap" Version="3.4.3" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
4 packages were updated in 3 projects:
`Nuke.Common`, `Serilog`, `CliWrap`, `CliFx`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Nuke.Common` to `6.0.2` from `6.0.1`
`Nuke.Common 6.0.2` was published at `2022-04-12T23:15:18Z`, 11 days ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.0.2` from `6.0.1`

[Nuke.Common 6.0.2 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.0.2)

NuKeeper has generated a minor update of `Serilog` to `2.11.0` from `2.10.0`
`Serilog 2.11.0` was published at `2022-04-24T00:10:14Z`, 5 hours ago

1 project update:
Updated `Samples/CsprojToAsmdef.Sample/Assets/SampleUnityDependency/SampleUnityDependency.csproj` to `Serilog` `2.11.0` from `2.10.0`

[Serilog 2.11.0 on NuGet.org](https://www.nuget.org/packages/Serilog/2.11.0)

NuKeeper has generated a patch update of `CliWrap` to `3.4.3` from `3.4.2`
`CliWrap 3.4.3` was published at `2022-04-17T23:52:11Z`, 6 days ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliWrap` `3.4.3` from `3.4.2`

[CliWrap 3.4.3 on NuGet.org](https://www.nuget.org/packages/CliWrap/3.4.3)

NuKeeper has generated a patch update of `CliFx` to `2.2.4` from `2.2.2`
`CliFx 2.2.4` was published at `2022-04-22T16:28:27Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.4` from `2.2.2`

[CliFx 2.2.4 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.4)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
