### PR TITLE
Automatic update of Nuke.Common to 6.0.3

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.2" />
+    <PackageReference Include="Nuke.Common" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Nuke.Common` to `6.0.3` from `6.0.2`
`Nuke.Common 6.0.3` was published at `2022-05-02T15:05:42Z`, 14 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.0.3` from `6.0.2`

[Nuke.Common 6.0.3 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
