### PR TITLE
Automatic update of FluentValidation to 11.0.1

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentValidation` to `11.0.1` from `11.0.0`
`FluentValidation 11.0.1` was published at `2022-05-07T11:12:42Z`, 18 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `11.0.1` from `11.0.0`

[FluentValidation 11.0.1 on NuGet.org](https://www.nuget.org/packages/FluentValidation/11.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
