### PR TITLE
Automatic update of CliFx to 2.2.5

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.4" />
+    <PackageReference Include="CliFx" Version="2.2.5" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
     <PackageReference Include="Microsoft.Build" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `CliFx` to `2.2.5` from `2.2.4`
`CliFx 2.2.5` was published at `2022-05-09T20:33:35Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.5` from `2.2.4`

[CliFx 2.2.5 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
