### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.2.5" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
     <PackageReference Include="Microsoft.Build" Version="17.2.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.2.5" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
-    <PackageReference Include="Microsoft.Build" Version="17.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.2.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
4 packages were updated in 2 projects:
`System.Text.Json`, `Microsoft.Build`, `Microsoft.Build.Utilities.Core`, `Microsoft.NET.Test.Sdk`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `System.Text.Json` to `6.0.4` from `6.0.3`
`System.Text.Json 6.0.4` was published at `2022-05-10T14:36:18Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Text.Json` `6.0.4` from `6.0.3`

[System.Text.Json 6.0.4 on NuGet.org](https://www.nuget.org/packages/System.Text.Json/6.0.4)

NuKeeper has generated a minor update of `Microsoft.Build` to `17.2.0` from `17.1.0`
`Microsoft.Build 17.2.0` was published at `2022-05-11T20:30:10Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `17.2.0` from `17.1.0`

[Microsoft.Build 17.2.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/17.2.0)

NuKeeper has generated a minor update of `Microsoft.Build.Utilities.Core` to `17.2.0` from `17.1.0`
`Microsoft.Build.Utilities.Core 17.2.0` was published at `2022-05-11T20:30:32Z`, 9 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `17.2.0` from `17.1.0`

[Microsoft.Build.Utilities.Core 17.2.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/17.2.0)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `17.2.0` from `17.1.0`
`Microsoft.NET.Test.Sdk 17.2.0` was published at `2022-05-11T09:07:34Z`, 20 hours ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.2.0` from `17.1.0`

[Microsoft.NET.Test.Sdk 17.2.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.2.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
