### PR TITLE
Automatic update of Roslynator.Analyzers to 4.1.1

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.1.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.39.0.47922" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Roslynator.Analyzers` to `4.1.1` from `4.1.0`
`Roslynator.Analyzers 4.1.1` was published at `2022-05-29T22:03:19Z`, 8 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `Roslynator.Analyzers` `4.1.1` from `4.1.0`

[Roslynator.Analyzers 4.1.1 on NuGet.org](https://www.nuget.org/packages/Roslynator.Analyzers/4.1.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
