### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
+++ b/Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props
@@ -22,7 +22,7 @@
     <UnityBuildTarget>StandaloneWindows:5</UnityBuildTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Unity3D" Version="1.7.0" />
+    <PackageReference Include="Unity3D" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" />

--- a/Sources/CsprojToAsmdef/Assets/Directory.Build.props
+++ b/Sources/CsprojToAsmdef/Assets/Directory.Build.props
@@ -25,7 +25,7 @@
     <UnityBuildTarget>StandaloneWindows:5</UnityBuildTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Unity3D" Version="1.7.0" />
+    <PackageReference Include="Unity3D" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.13.0" PrivateAssets="all" />

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.39.0.47922" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
2 packages were updated in 3 projects:
`Unity3D`, `SonarAnalyzer.CSharp`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Unity3D` to `2.0.1` from `1.7.0`
`Unity3D 2.0.1` was published at `2022-06-01T05:59:25Z`, 10 minutes ago

2 project updates:
Updated `Sources/CsprojToAsmdef/Assets/Directory.Build.props` to `Unity3D` `2.0.1` from `1.7.0`
Updated `Samples/CsprojToAsmdef.Sample/Assets/Directory.Build.props` to `Unity3D` `2.0.1` from `1.7.0`

[Unity3D 2.0.1 on NuGet.org](https://www.nuget.org/packages/Unity3D/2.0.1)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.40.0.48530` from `8.39.0.47922`
`SonarAnalyzer.CSharp 8.40.0.48530` was published at `2022-05-31T08:58:29Z`, 21 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.40.0.48530` from `8.39.0.47922`

[SonarAnalyzer.CSharp 8.40.0.48530 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.40.0.48530)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
