### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.3" />
+    <PackageReference Include="Nuke.Common" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.5" />
+    <PackageReference Include="CliFx" Version="2.2.6" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
     <PackageReference Include="Microsoft.Build" Version="17.2.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Nuke.Common`, `CliFx`, `System.Text.Json`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Nuke.Common` to `6.1.0` from `6.0.3`
`Nuke.Common 6.1.0` was published at `2022-06-14T21:40:12Z`, 8 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.1.0` from `6.0.3`

[Nuke.Common 6.1.0 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.1.0)

NuKeeper has generated a patch update of `CliFx` to `2.2.6` from `2.2.5`
`CliFx 2.2.6` was published at `2022-06-14T19:40:47Z`, 10 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.2.6` from `2.2.5`

[CliFx 2.2.6 on NuGet.org](https://www.nuget.org/packages/CliFx/2.2.6)

NuKeeper has generated a patch update of `System.Text.Json` to `6.0.5` from `6.0.4`
`System.Text.Json 6.0.5` was published at `2022-06-14T14:13:18Z`, 15 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `System.Text.Json` `6.0.5` from `6.0.4`

[System.Text.Json 6.0.5 on NuGet.org](https://www.nuget.org/packages/System.Text.Json/6.0.5)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
