### PR TITLE
Automatic update of Nuke.Common to 6.1.1

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.0" />
+    <PackageReference Include="Nuke.Common" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Nuke.Common` to `6.1.1` from `6.1.0`
`Nuke.Common 6.1.1` was published at `2022-06-21T21:50:53Z`, 8 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.1.1` from `6.1.0`

[Nuke.Common 6.1.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.1.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
