### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.0" />
+    <PackageReference Include="Nuke.Common" Version="6.1.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.0.3" />
+    <PackageReference Include="FluentValidation" Version="11.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
2 packages were updated in 2 projects:
`FluentValidation`, `Nuke.Common`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `FluentValidation` to `11.1.0` from `11.0.3`
`FluentValidation 11.1.0` was published at `2022-06-22T15:20:55Z`, 10 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `11.1.0` from `11.0.3`

[FluentValidation 11.1.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/11.1.0)

NuKeeper has generated a patch update of `Nuke.Common` to `6.1.2` from `6.1.0`
`Nuke.Common 6.1.2` was published at `2022-07-02T20:37:47Z`, 9 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.1.2` from `6.1.0`

[Nuke.Common 6.1.2 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.1.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
