### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.41.0.50478

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.41.0.50478" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.41.0.50478` from `8.40.0.48530`
`SonarAnalyzer.CSharp 8.41.0.50478` was published at `2022-07-04T16:06:29Z`, 14 hours ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.41.0.50478` from `8.40.0.48530`

[SonarAnalyzer.CSharp 8.41.0.50478 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.41.0.50478)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
