### PR TITLE
Automatic update of CliFx to 2.3.0

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliFx" Version="2.2.6" />
+    <PackageReference Include="CliFx" Version="2.3.0" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
     <PackageReference Include="Microsoft.Build" Version="17.2.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `CliFx` to `2.3.0` from `2.2.6`
`CliFx 2.3.0` was published at `2022-07-12T11:41:33Z`, 18 hours ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliFx` `2.3.0` from `2.2.6`

[CliFx 2.3.0 on NuGet.org](https://www.nuget.org/packages/CliFx/2.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
