### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.42.0.51121" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
3 packages were updated in 3 projects:
`SonarAnalyzer.CSharp`, `FluentValidation`, `xunit`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.43.0.51858` from `8.42.0.51121`
`SonarAnalyzer.CSharp 8.43.0.51858` was published at `2022-08-03T09:12:33Z`, 5 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.43.0.51858` from `8.42.0.51121`

[SonarAnalyzer.CSharp 8.43.0.51858 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.43.0.51858)

NuKeeper has generated a minor update of `FluentValidation` to `11.2.0` from `11.1.0`
`FluentValidation 11.2.0` was published at `2022-08-08T18:36:59Z`, 11 hours ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `11.2.0` from `11.1.0`

[FluentValidation 11.2.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/11.2.0)

NuKeeper has generated a patch update of `xunit` to `2.4.2` from `2.4.1`
`xunit 2.4.2` was published at `2022-08-01T21:42:30Z`, 7 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `xunit` `2.4.2` from `2.4.1`

[xunit 2.4.2 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
