### PR TITLE
Automatic update of 5 packages

### DIFF
--- a/Build/CsprojToAsmdef.Build.csproj
+++ b/Build/CsprojToAsmdef.Build.csproj
@@ -12,7 +12,7 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.2" />
+    <PackageReference Include="Nuke.Common" Version="6.2.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-format" Version="[5.1.250801]" />

--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.42.0.51121" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
5 packages were updated in 4 projects:
`SonarAnalyzer.CSharp`, `FluentValidation`, `Microsoft.NET.Test.Sdk`, `xunit`, `Nuke.Common`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.43.0.51858` from `8.42.0.51121`
`SonarAnalyzer.CSharp 8.43.0.51858` was published at `2022-08-03T09:12:33Z`, 15 days ago

1 project update:
Updated `Sources/Directory.Build.props` to `SonarAnalyzer.CSharp` `8.43.0.51858` from `8.42.0.51121`

[SonarAnalyzer.CSharp 8.43.0.51858 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.43.0.51858)

NuKeeper has generated a minor update of `FluentValidation` to `11.2.0` from `11.1.0`
`FluentValidation 11.2.0` was published at `2022-08-08T18:36:59Z`, 10 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `11.2.0` from `11.1.0`

[FluentValidation 11.2.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation/11.2.0)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `17.3.0` from `17.2.0`
`Microsoft.NET.Test.Sdk 17.3.0` was published at `2022-08-10T10:02:29Z`, 8 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.3.0` from `17.2.0`

[Microsoft.NET.Test.Sdk 17.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.0)

NuKeeper has generated a patch update of `xunit` to `2.4.2` from `2.4.1`
`xunit 2.4.2` was published at `2022-08-01T21:42:30Z`, 17 days ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `xunit` `2.4.2` from `2.4.1`

[xunit 2.4.2 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.2)

NuKeeper has generated a minor update of `Nuke.Common` to `6.2.1` from `6.1.2`
`Nuke.Common 6.2.1` was published at `2022-08-19T00:21:06Z`, 5 hours ago

1 project update:
Updated `Build/CsprojToAsmdef.Build.csproj` to `Nuke.Common` `6.2.1` from `6.1.2`

[Nuke.Common 6.2.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/6.2.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
