### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.0" />
     <PackageReference Include="CliWrap" Version="3.5.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.3.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.0" />
-    <PackageReference Include="CliWrap" Version="3.4.4" />
+    <PackageReference Include="CliWrap" Version="3.5.0" />
     <PackageReference Include="Microsoft.Build" Version="17.2.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
+++ b/Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CliFx" Version="2.3.0" />
     <PackageReference Include="CliWrap" Version="3.5.0" />
     <PackageReference Include="Microsoft.Build" Version="17.3.1" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />


### PR DESCRIPTION
3 packages were updated in 1 project:
`CliWrap`, `Microsoft.Build`, `Microsoft.Build.Utilities.Core`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `CliWrap` to `3.5.0` from `3.4.4`
`CliWrap 3.5.0` was published at `2022-08-24T22:16:16Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `CliWrap` `3.5.0` from `3.4.4`

[CliWrap 3.5.0 on NuGet.org](https://www.nuget.org/packages/CliWrap/3.5.0)

NuKeeper has generated a minor update of `Microsoft.Build` to `17.3.1` from `17.2.0`
`Microsoft.Build 17.3.1` was published at `2022-08-24T19:00:25Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build` `17.3.1` from `17.2.0`

[Microsoft.Build 17.3.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build/17.3.1)

NuKeeper has generated a minor update of `Microsoft.Build.Utilities.Core` to `17.3.1` from `17.2.0`
`Microsoft.Build.Utilities.Core 17.3.1` was published at `2022-08-24T19:00:42Z`, 1 day ago

1 project update:
Updated `Sources/CsprojToAsmdef.Cli/CsprojToAsmdef.Cli.csproj` to `Microsoft.Build.Utilities.Core` `17.3.1` from `17.2.0`

[Microsoft.Build.Utilities.Core 17.3.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core/17.3.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
