### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Samples/OtherExternalDependency/OtherExternalDependency.csproj
+++ b/Samples/OtherExternalDependency/OtherExternalDependency.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.2.0" />
+    <PackageReference Include="FluentValidation" Version="11.2.1" />
   </ItemGroup>
 
 </Project>

--- a/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
+++ b/Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
2 packages were updated in 2 projects:
`FluentValidation`, `Microsoft.NET.Test.Sdk`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `FluentValidation` to `11.2.1` from `11.2.0`
`FluentValidation 11.2.1` was published at `2022-08-28T12:17:54Z`, 2 days ago

1 project update:
Updated `Samples/OtherExternalDependency/OtherExternalDependency.csproj` to `FluentValidation` `11.2.1` from `11.2.0`

[FluentValidation 11.2.1 on NuGet.org](https://www.nuget.org/packages/FluentValidation/11.2.1)

NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `17.3.1` from `17.3.0`
`Microsoft.NET.Test.Sdk 17.3.1` was published at `2022-08-30T10:23:23Z`, 20 hours ago

1 project update:
Updated `Tests/CsprojToAsmdef.Tests/CsprojToAsmdef.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.3.1` from `17.3.0`

[Microsoft.NET.Test.Sdk 17.3.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
